### PR TITLE
"Experimental Rocketry" duplication with B9.

### DIFF
--- a/KWPatch.cfg
+++ b/KWPatch.cfg
@@ -81,9 +81,10 @@
 
 
 //New tech node to house the BIG engines
+
 @TechTree
 {
-	RDNode:NEEDS[!CommunityTechTree]
+	RDNode:NEEDS[!CommunityTechTree&!B9_Aerospace]
 	{
 		id = experimentalRocketry
 		title = Experimental Rocketry
@@ -101,6 +102,16 @@
 			lineFrom = RIGHT
 			lineTo = LEFT
 		}
+		Parent
+		{
+			parentID = highPerformanceFuelSystems
+			lineFrom = RIGHT
+			lineTo = LEFT
+		}
+	}
+	
+	@RDNode:HAS[#id[experimentalRocketry]]:AFTER[B9_Aerospace]:NEEDS[!CommunityTechTree&B9_Aerospace]
+	{
 		Parent
 		{
 			parentID = highPerformanceFuelSystems


### PR DESCRIPTION
When B9 AeroSpace is installed and CommunityTechTree is not, the node "Experimental Rocketry", where the last engines of both mods sit, is duplicated at the same position.

This fix handles this situation by preventing any action from KW Community Patch but still adding the requirement to unlock the "High Performance Fuel System" node.
